### PR TITLE
Remove obsolete and unused timezone struct

### DIFF
--- a/lib/wtime.c
+++ b/lib/wtime.c
@@ -20,6 +20,7 @@
  *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 #include <sys/time.h>
+#include <stddef.h>
 #include "sys/resource.h"
 #ifdef RUSAGE_SELF
 #else
@@ -28,16 +29,15 @@
 
 double primme_wTimer(int zeroTimer) {
    static struct timeval tv;
-   static struct timezone tz;
    static double StartingTime;
    
    if (zeroTimer) {
-      gettimeofday(&tv, &tz); 
+      gettimeofday(&tv, NULL);
       StartingTime = ((double) tv.tv_sec) + ((double) tv.tv_usec )/(double) 1E6;
       return StartingTime;
    }
    else {
-      gettimeofday(&tv, &tz); 
+      gettimeofday(&tv, NULL);
       return ((double) tv.tv_sec) + ((double) tv.tv_usec ) / (double) 1E6
 	   - StartingTime;
    }
@@ -73,9 +73,8 @@ double primme_wTimer(int zeroTimer) {
 /* Simply return the microseconds time of day */
 double primme_get_wtime() {
    static struct timeval tv;
-   static struct timezone tz;
 
-   gettimeofday(&tv, &tz); 
+   gettimeofday(&tv, NULL);
    return ((double) tv.tv_sec) + ((double) tv.tv_usec ) / (double) 1E6;
 }
 


### PR DESCRIPTION
Actually compilations failed because the compiler couldnt find the timezone struct.

Obsolete as mentioned in `man 2 gettimeofday` on probably most systems.